### PR TITLE
Fix Issue #15

### DIFF
--- a/src/me/vik1395/BungeeAuth/Login.java
+++ b/src/me/vik1395/BungeeAuth/Login.java
@@ -160,7 +160,13 @@ public class Login extends Command
 							Main.plonline.add(pName);
 							ct.setStatus(pName, "online");
 							ListenerClass.movePlayer(p, false);
-							ListenerClass.prelogin.get(pName).cancel();
+							//If guestsession is set to 0, this will produced an error.
+							//see Issue #15.
+							//This will prevent the error. 
+							if(Main.gseshlength != 0){
+								ListenerClass.prelogin.get(pName).cancel();
+							}
+							
 							p.sendMessage(new ComponentBuilder(Main.login_success).color(ChatColor.GREEN).create());
 						}
 					}


### PR DESCRIPTION
The line "ListenerClass.prelogin.get..." will produce an error if the guest session length is set to 0.
The Class ListenerClass only adds an entry in prelogin if the guest session length is not 0. So this will
produces a Nullpointer-Exception.
I will be more clear on the issue page from EnderCraft202.

Regards 
Bloodrayne1995